### PR TITLE
4 open source embeddings model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 __pycache__
 topics.json
 chroma
+.venv/
+.vscode

--- a/prompt_manager/app/tools/embeddor.py
+++ b/prompt_manager/app/tools/embeddor.py
@@ -1,0 +1,17 @@
+from langchain_ollama import OllamaEmbeddings
+from typing import List
+
+def OpenSourceEmbeddingsModel(name : str = "embeddinggemma:latest"):
+    """Instantiate the Ollama Embeddings Model"""
+    model = OllamaEmbeddings(model=name,
+                             validate_model_on_init=True,
+                             base_url="http://127.0.0.1:11434")
+    
+    return model
+
+# # Accessing and using the model
+# model = OpenSourceEmbeddingsModel()
+# query = model.embed_query("Hello")
+# print(query[:5])
+# print("Dimensions : ", len(query))
+# print("Type : ", type(query))


### PR DESCRIPTION
Added the **embeddor.py** file which contains the open source embeddings model.

Note : 
1. You need to install ollama and the model (embeddinggemma:latest) locally on your computer